### PR TITLE
fix: Forcing test migration

### DIFF
--- a/backend/src/ormconfig.ts
+++ b/backend/src/ormconfig.ts
@@ -13,5 +13,4 @@ const ormconfig: TypeOrmModuleOptions = {
   entities: [FileInfo, Observation],
   synchronize: false,
 };
-
 export default ormconfig;

--- a/migrations/sql/R__test_data.sql
+++ b/migrations/sql/R__test_data.sql
@@ -1,3 +1,0 @@
--- INSERT INTO file_info (id, file_name, date_created) 
--- VALUES ('0d205adb-5989-436c-bcad-62520c8c29f3', 'sampling_locations_06_03_2025__08_57_40.gpkg', '2025-06-03 00:00:00') 
--- ON CONFLICT DO NOTHING;


### PR DESCRIPTION
The flyway scripts to autovacuum the observations table wasn't executed.  Possibly because there were multiple PRs in action.  This PR attempts to rerun the script.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-enmods-wr-46-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-enmods-wr-46-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-enmods-wr/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-enmods-wr/actions/workflows/merge.yml)