### PR TITLE
fix: Update Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -33,7 +33,7 @@ USER appuser
 
 # Boilerplate, not used in OpenShift/Kubernetes
 EXPOSE 3000
-HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost:3000/api
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD curl -f http://localhost:3000/api
 
 # limit heap size to 512 MB~
 CMD ["node", "--max-old-space-size=512", "/app/dist/main.js"]


### PR DESCRIPTION
The backend container was restarting under heavy load.  It didn't appear to be a result of running out of memory or CPU.  That said, it may be possible that the health checks were taking longer to respond under heady load, so increasing the healthcheck timeout, and added retries.


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-enmods-wr-52-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-enmods-wr-52-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-enmods-wr/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-enmods-wr/actions/workflows/merge.yml)