### PR TITLE
fix: Add public-read header to objectstore upload

### DIFF
--- a/backend/src/geodata/geodata.service.ts
+++ b/backend/src/geodata/geodata.service.ts
@@ -1047,14 +1047,16 @@ export class GeodataService {
     const canonicalizedResource = `/${OBJECTSTORE_BUCKET}/${objectPath}`;
     const requestUrl = `${OBJECTSTORE_URL}/${OBJECTSTORE_BUCKET}/${objectPath}`;
 
-    const signature = crypto
-      .createHmac("sha1", OBJECTSTORE_SECRET_KEY)
-      .update(`PUT\n\n${contentType}\n${dateValue}\n${canonicalizedResource}`)
-      .digest("base64");
-
     // Get file size for Content-Length header
     const stats = fs.statSync(file.path);
     const fileSize = stats.size;
+
+    const signature = crypto
+      .createHmac("sha1", OBJECTSTORE_SECRET_KEY)
+      .update(
+        `PUT\n\n${contentType}\n${dateValue}\nx-amz-acl:public-read\n${canonicalizedResource}`,
+      )
+      .digest("base64");
 
     const headers = {
       Authorization: `AWS ${OBJECTSTORE_ACCESS_KEY}:${signature}`,
@@ -1062,6 +1064,7 @@ export class GeodataService {
       "Content-Type": contentType,
       "Content-Length": fileSize,
       Host: new URL(OBJECTSTORE_URL).host,
+      "x-amz-acl": "public-read",
     };
 
     try {


### PR DESCRIPTION
This pull request updates the way files are uploaded to the object store to ensure they are publicly accessible by default. The main change is the addition of the `x-amz-acl: public-read` header and its inclusion in the signature calculation for authentication.

**Object store upload improvements:**

* Added the `x-amz-acl: public-read` header to the upload request to make uploaded files publicly accessible.
* Updated the signature generation to include the `x-amz-acl:public-read` line, ensuring the request is properly authenticated when specifying public access.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-enmods-wr-99-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-enmods-wr-99-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-enmods-wr/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-enmods-wr/actions/workflows/merge.yml)