### PR TITLE
fix: Update problem data points handling

### DIFF
--- a/backend/src/geodata/geodata.service.ts
+++ b/backend/src/geodata/geodata.service.ts
@@ -498,6 +498,21 @@ export class GeodataService {
     return attribute ? attribute.text : "";
   }
 
+  getLon(longitude: string): number | null {
+    if (!longitude || longitude === "") return null;
+    if (isNaN(parseFloat(longitude))) return null;
+    if (parseFloat(longitude) < -180 || parseFloat(longitude) > 180)
+      return null;
+    return parseFloat(longitude);
+  }
+
+  getLat(latitude: string): number | null {
+    if (!latitude || latitude === "") return null;
+    if (isNaN(parseFloat(latitude))) return null;
+    if (parseFloat(latitude) < -90 || parseFloat(latitude) > 90) return null;
+    return parseFloat(latitude);
+  }
+
   /**
    * 1. Receives and converts raw data to a simplified geojson format from processAndUpload
    * 2. Passes this on to intersectAndGenerate for file operations
@@ -521,8 +536,8 @@ export class GeodataService {
             geometry: {
               type: "Point",
               coordinates: [
-                location.longitude ? parseFloat(location.longitude) : null,
-                location.latitude ? parseFloat(location.latitude) : null,
+                this.getLon(location.longitude),
+                this.getLat(location.latitude),
               ],
             },
             properties: {


### PR DESCRIPTION
Points well outside the dataset were being added to test data causing intersects to fail, these data points were therefore being removed from the dataset. This was not wanted so the logic has been updated to set these lat/lon values to null for the intersect calculation but to include the the points in the dataset.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-enmods-wr-123-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-enmods-wr-123-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-enmods-wr/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-enmods-wr/actions/workflows/merge.yml)