### PR TITLE
feat: mutli select work order number

### DIFF
--- a/backend/src/materialized-views/mv_aqi_analysis_method.entity.ts
+++ b/backend/src/materialized-views/mv_aqi_analysis_method.entity.ts
@@ -1,7 +1,0 @@
-import { ViewEntity, ViewColumn } from 'typeorm';
-
-@ViewEntity({ name: 'mv_aqi_analysis_method' })
-export class MvAqiAnalysisMethod {
-  @ViewColumn({ name: 'analysis_method' })
-  analysis_method: string;
-}

--- a/backend/src/materialized-views/mv_aqi_analysis_method_collection.entity.ts
+++ b/backend/src/materialized-views/mv_aqi_analysis_method_collection.entity.ts
@@ -1,0 +1,10 @@
+import { ViewEntity, ViewColumn } from "typeorm";
+
+@ViewEntity({ name: "mv_aqi_analysis_method_collection" })
+export class MvAqiAnalysisMethodCollection {
+  @ViewColumn({ name: "analysis_method_id" })
+  analysis_method_id: string;
+
+  @ViewColumn({ name: "analysis_method" })
+  analysis_method: string;
+}

--- a/backend/src/ormconfig.ts
+++ b/backend/src/ormconfig.ts
@@ -17,7 +17,7 @@ import { MvAqiObservedPropertyResultType } from "./materialized-views/mv_aqi_obs
 import { MvAqiObservedPropertyAnalysisType } from "./materialized-views/mv_aqi_observed_property_analysis_type.entity";
 import { MvAqiDataClassification } from "./materialized-views/mv_aqi_data_classification.entity";
 import { MvAqiAnalyzingAgency } from "./materialized-views/mv_aqi_analyzing_agency.entity";
-import { MvAqiAnalysisMethod } from "./materialized-views/mv_aqi_analysis_method.entity";
+import { MvAqiAnalysisMethodCollection } from "./materialized-views/mv_aqi_analysis_method_collection.entity";
 import { MvAqiLabBatchId } from "./materialized-views/mv_aqi_lab_batch_id.entity";
 import { MvAqiQcType } from "./materialized-views/mv_aqi_qc_type.entity";
 import { S3SyncLog } from "./s3_sync_log/entities/s3_sync_log.entity";
@@ -49,7 +49,7 @@ const ormconfig: TypeOrmModuleOptions = {
     MvAqiObservedPropertyAnalysisType,
     MvAqiDataClassification,
     MvAqiAnalyzingAgency,
-    MvAqiAnalysisMethod,
+    MvAqiAnalysisMethodCollection,
     MvAqiLabBatchId,
     MvAqiQcType,
     S3SyncLog,

--- a/backend/src/search/search.controller.ts
+++ b/backend/src/search/search.controller.ts
@@ -45,6 +45,7 @@ export class SearchController {
       "collectionMethod",
       "qcSampleType",
       "dataClassification",
+      "workedOrderNo",
     ];
 
     const normalized: any = {};
@@ -67,12 +68,7 @@ export class SearchController {
               customId: queryParams.locationTypeCustomId,
             }
           : "";
-      } else if (key === "workedOrderNo") {
-        // Special handling for workedOrderNo which is an object
-        normalized[key] = queryParams.workedOrderNo
-          ? { id: queryParams.workedOrderNo, text: queryParams.workOrderNoText }
-          : "";
-      } else if (key !== "locationTypeCustomId" && key !== "workOrderNoText") {
+      } else if (key !== "locationTypeCustomId") {
         // Copy other fields as-is, excluding the intermediate fields
         normalized[key] = value || "";
       }

--- a/backend/src/search/search.controller.ts
+++ b/backend/src/search/search.controller.ts
@@ -60,6 +60,13 @@ export class SearchController {
         } else {
           normalized[key] = "";
         }
+      } else if (key === "workOrderNoText") {
+        // Handle workOrderNoText from URL and convert to workedOrderNo format
+        if (typeof value === "string" && value) {
+          normalized["workedOrderNo"] = [{ text: value }];
+        } else {
+          normalized["workedOrderNo"] = "";
+        }
       } else if (key === "locationType") {
         // Special handling for locationType which is an object
         normalized[key] = queryParams.locationType

--- a/backend/src/search/search.service.ts
+++ b/backend/src/search/search.service.ts
@@ -145,7 +145,7 @@ export class SearchService {
       basicSearchDto.analyticalMethod &&
       basicSearchDto.analyticalMethod.length >= 1
     ) {
-      whereClause.push(`analysis_method = ANY($${params.length + 1})`);
+      whereClause.push(`analysis_method_id = ANY($${params.length + 1})`);
       params.push(basicSearchDto.analyticalMethod);
     }
 
@@ -627,20 +627,20 @@ export class SearchService {
    */
   public async getAnalyticalMethods(): Promise<any[]> {
     this.logger.log(
-      "getAnalyticalMethods called, querying materialized view mv_aqi_analysis_method",
+      "getAnalyticalMethods called, querying materialized view mv_aqi_analysis_method_collection",
     );
     const repo = this["observationRepository"].manager.getRepository(
-      "mv_aqi_analysis_method",
+      "mv_aqi_analysis_method_collection",
     );
     const raw = await repo
       .createQueryBuilder()
       .select()
-      .orderBy("MvAqiAnalysisMethod.analysis_method", "ASC")
+      .orderBy("MvAqiAnalysisMethodCollection.analysis_method", "ASC")
       .getRawMany();
     // Return as array of objects for frontend dropdown compatibility
     return raw.map((item) => ({
-      id: item.MvAqiAnalysisMethod_analysis_method,
-      name: item.MvAqiAnalysisMethod_analysis_method,
+      id: item.MvAqiAnalysisMethodCollection_analysis_method_id,
+      name: item.MvAqiAnalysisMethodCollection_analysis_method,
     }));
   }
 

--- a/backend/src/search/search.service.ts
+++ b/backend/src/search/search.service.ts
@@ -107,9 +107,12 @@ export class SearchService {
       params.push(basicSearchDto.observedProperty);
     }
 
-    if (basicSearchDto.workedOrderNo) {
-      whereClause.push(`work_order_number = $${params.length + 1}`);
-      params.push(basicSearchDto.workedOrderNo.text);
+    if (
+      basicSearchDto.workedOrderNo &&
+      basicSearchDto.workedOrderNo.length >= 1
+    ) {
+      whereClause.push(`work_order_number = ANY($${params.length + 1})`);
+      params.push(basicSearchDto.workedOrderNo.map((order: any) => order.text));
     }
 
     if (

--- a/backend/src/search/search.service.ts
+++ b/backend/src/search/search.service.ts
@@ -111,8 +111,13 @@ export class SearchService {
       basicSearchDto.workedOrderNo &&
       basicSearchDto.workedOrderNo.length >= 1
     ) {
-      whereClause.push(`work_order_number = ANY($${params.length + 1})`);
-      params.push(basicSearchDto.workedOrderNo.map((order: any) => order.text));
+      const validOrderNumbers = basicSearchDto.workedOrderNo
+        .filter((order: any) => order && order.text)
+        .map((order: any) => order.text);
+      if (validOrderNumbers.length > 0) {
+        whereClause.push(`work_order_number = ANY($${params.length + 1})`);
+        params.push(validOrderNumbers);
+      }
     }
 
     if (

--- a/frontend/src/components/search/FilterResultsForm.tsx
+++ b/frontend/src/components/search/FilterResultsForm.tsx
@@ -183,12 +183,7 @@ export default function FilterResultsForm(props: any) {
                 <Autocomplete
                   multiple
                   value={formData?.workedOrderNo || []}
-                  inputValue={workOrderInputValue}
-                  onInputChange={(e, val) => {
-                    setWorkOrderInputValue(val)
-                  }}
-                  options={getFilteredWorkOrders()}
-                  filterOptions={(options) => options}
+                  options={filterResultDrpdwns.workedOrderNos || []}
                   getOptionKey={(option) => option.text}
                   isOptionEqualToValue={(option, value) =>
                     option.text === value.text
@@ -196,11 +191,6 @@ export default function FilterResultsForm(props: any) {
                   getOptionLabel={(option) => option.text || ""}
                   onChange={(e, val) =>
                     handleOnChange(e, val, SearchAttr.WorkedOrderNo)
-                  }
-                  noOptionsText={
-                    workOrderInputValue.length < 3
-                      ? `Type at least ${3 - workOrderInputValue.length} more characters`
-                      : "No matching work orders"
                   }
                   sx={{ width: 380 }}
                   renderInput={(params) => (

--- a/frontend/src/components/search/FilterResultsForm.tsx
+++ b/frontend/src/components/search/FilterResultsForm.tsx
@@ -181,23 +181,21 @@ export default function FilterResultsForm(props: any) {
 
               <div className="flex items-center">
                 <Autocomplete
-                  multiple
-                  value={formData?.workedOrderNo || []}
+                  value={formData?.workedOrderNo}
                   inputValue={workOrderInputValue}
                   onInputChange={(e, val) => {
                     setWorkOrderInputValue(val)
                   }}
                   options={getFilteredWorkOrders()}
                   filterOptions={(options) => options}
-                  getOptionKey={(option) => option.text}
+                  getOptionKey={(option) => option.id}
                   isOptionEqualToValue={(option, value) =>
-                    option.text === value.text
+                    option.id === value.id
                   }
                   getOptionLabel={(option) => option.text || ""}
-                  onChange={(e, val) => {
+                  onChange={(e, val) =>
                     handleOnChange(e, val, SearchAttr.WorkedOrderNo)
-                    setWorkOrderInputValue("")
-                  }}
+                  }
                   noOptionsText={
                     workOrderInputValue.length < 3
                       ? `Type at least ${3 - workOrderInputValue.length} more characters`

--- a/frontend/src/components/search/FilterResultsForm.tsx
+++ b/frontend/src/components/search/FilterResultsForm.tsx
@@ -305,7 +305,7 @@ export default function FilterResultsForm(props: any) {
                   <TextField {...params} label="Analysis Method ID" />
                 )}
               />
-              <TooltipInfo title="The laboratory analytical method used to analyze a sample." />
+              <TooltipInfo title="The unique system ID for the lab analysis method." />
             </div>
 
           </div>

--- a/frontend/src/components/search/FilterResultsForm.tsx
+++ b/frontend/src/components/search/FilterResultsForm.tsx
@@ -183,15 +183,20 @@ export default function FilterResultsForm(props: any) {
                 <Autocomplete
                   multiple
                   value={formData?.workedOrderNo || []}
+                  inputValue={workOrderInputValue}
+                  onInputChange={(e, val) => {
+                    setWorkOrderInputValue(val)
+                  }}
                   options={filterResultDrpdwns.workedOrderNos || []}
                   getOptionKey={(option) => option.text}
                   isOptionEqualToValue={(option, value) =>
                     option.text === value.text
                   }
                   getOptionLabel={(option) => option.text || ""}
-                  onChange={(e, val) =>
+                  onChange={(e, val) => {
                     handleOnChange(e, val, SearchAttr.WorkedOrderNo)
-                  }
+                    setWorkOrderInputValue("")
+                  }}
                   sx={{ width: 380 }}
                   renderInput={(params) => (
                     <TextField {...params} label="Work Order Number" />

--- a/frontend/src/components/search/FilterResultsForm.tsx
+++ b/frontend/src/components/search/FilterResultsForm.tsx
@@ -181,6 +181,7 @@ export default function FilterResultsForm(props: any) {
 
               <div className="flex items-center">
                 <Autocomplete
+                  multiple
                   value={formData?.workedOrderNo}
                   inputValue={workOrderInputValue}
                   onInputChange={(e, val) => {

--- a/frontend/src/components/search/FilterResultsForm.tsx
+++ b/frontend/src/components/search/FilterResultsForm.tsx
@@ -182,21 +182,17 @@ export default function FilterResultsForm(props: any) {
               <div className="flex items-center">
                 <Autocomplete
                   multiple
+                  freeSolo
                   value={formData?.workedOrderNo || []}
-                  inputValue={workOrderInputValue}
-                  onInputChange={(e, val) => {
-                    setWorkOrderInputValue(val)
-                  }}
                   options={filterResultDrpdwns.workedOrderNos || []}
                   getOptionKey={(option) => option.text}
                   isOptionEqualToValue={(option, value) =>
                     option.text === value.text
                   }
                   getOptionLabel={(option) => option.text || ""}
-                  onChange={(e, val) => {
+                  onChange={(e, val) =>
                     handleOnChange(e, val, SearchAttr.WorkedOrderNo)
-                    setWorkOrderInputValue("")
-                  }}
+                  }
                   sx={{ width: 380 }}
                   renderInput={(params) => (
                     <TextField {...params} label="Work Order Number" />

--- a/frontend/src/components/search/FilterResultsForm.tsx
+++ b/frontend/src/components/search/FilterResultsForm.tsx
@@ -184,14 +184,24 @@ export default function FilterResultsForm(props: any) {
                   multiple
                   freeSolo
                   value={formData?.workedOrderNo || []}
-                  options={filterResultDrpdwns.workedOrderNos || []}
+                  inputValue={workOrderInputValue}
+                  onInputChange={(e, val) => {
+                    setWorkOrderInputValue(val)
+                  }}
+                  options={getFilteredWorkOrders()}
                   getOptionKey={(option) => option.text}
                   isOptionEqualToValue={(option, value) =>
                     option.text === value.text
                   }
                   getOptionLabel={(option) => option.text || ""}
-                  onChange={(e, val) =>
+                  onChange={(e, val) => {
                     handleOnChange(e, val, SearchAttr.WorkedOrderNo)
+                    setWorkOrderInputValue("")
+                  }}
+                  noOptionsText={
+                    workOrderInputValue.length < 3
+                      ? `Type at least ${3 - workOrderInputValue.length} more characters`
+                      : "No matching work orders"
                   }
                   sx={{ width: 380 }}
                   renderInput={(params) => (

--- a/frontend/src/components/search/FilterResultsForm.tsx
+++ b/frontend/src/components/search/FilterResultsForm.tsx
@@ -182,13 +182,13 @@ export default function FilterResultsForm(props: any) {
               <div className="flex items-center">
                 <Autocomplete
                   multiple
-                  freeSolo
                   value={formData?.workedOrderNo || []}
                   inputValue={workOrderInputValue}
                   onInputChange={(e, val) => {
                     setWorkOrderInputValue(val)
                   }}
                   options={getFilteredWorkOrders()}
+                  filterOptions={(options) => options}
                   getOptionKey={(option) => option.text}
                   isOptionEqualToValue={(option, value) =>
                     option.text === value.text

--- a/frontend/src/components/search/FilterResultsForm.tsx
+++ b/frontend/src/components/search/FilterResultsForm.tsx
@@ -189,9 +189,9 @@ export default function FilterResultsForm(props: any) {
                   }}
                   options={getFilteredWorkOrders()}
                   filterOptions={(options) => options}
-                  getOptionKey={(option) => option.id}
+                  getOptionKey={(option) => option.text}
                   isOptionEqualToValue={(option, value) =>
-                    option.id === value.id
+                    option.text === value.text
                   }
                   getOptionLabel={(option) => option.text || ""}
                   onChange={(e, val) =>

--- a/frontend/src/components/search/FilterResultsForm.tsx
+++ b/frontend/src/components/search/FilterResultsForm.tsx
@@ -285,6 +285,29 @@ export default function FilterResultsForm(props: any) {
               />
               <TooltipInfo title="The laboratory analytical method used to analyze a sample." />
             </div>
+
+            <div className="flex items-center">
+              <Autocomplete
+                multiple
+                value={formData?.analyticalMethod}
+                getOptionKey={(option) => option.id}
+                options={filterResultDrpdwns.analyticalMethods}
+                isOptionEqualToValue={(option, value) => option.id === value.id}
+                getOptionLabel={(option) => option.id || ""}
+                onInputChange={(e, val) =>
+                  handleInputChange(e, val, SearchAttr.AnalyticalMethod)
+                }
+                onChange={(e, val) =>
+                  handleOnChange(e, val, SearchAttr.AnalyticalMethod)
+                }
+                sx={{ width: 380 }}
+                renderInput={(params) => (
+                  <TextField {...params} label="Analysis Method ID" />
+                )}
+              />
+              <TooltipInfo title="The laboratory analytical method used to analyze a sample." />
+            </div>
+
           </div>
         )}
       </div>

--- a/frontend/src/components/search/FilterResultsForm.tsx
+++ b/frontend/src/components/search/FilterResultsForm.tsx
@@ -182,7 +182,7 @@ export default function FilterResultsForm(props: any) {
               <div className="flex items-center">
                 <Autocomplete
                   multiple
-                  value={formData?.workedOrderNo}
+                  value={formData?.workedOrderNo || []}
                   inputValue={workOrderInputValue}
                   onInputChange={(e, val) => {
                     setWorkOrderInputValue(val)

--- a/frontend/src/interfaces/AdvanceSearchFormType.ts
+++ b/frontend/src/interfaces/AdvanceSearchFormType.ts
@@ -1,18 +1,16 @@
-import BasicSearchFormType from "./BasicSearchFormType";
+import BasicSearchFormType from "./BasicSearchFormType"
 
 export default interface AdvanceSearchFormType extends BasicSearchFormType {
-   
-    observationIds: string[],
-    observedProperty: string[],
-    workedOrderNo: any,
-    samplingAgency: string[],
-    analyzingAgency: string[],    
-    analyticalMethod: string[],
-    collectionMethod: string[],
-    qcSampleType: string[],
-    dataClassification: string[],
-    sampleDepth: string,
-    labBatchId: string,
-    specimenId: string, 
-
+  observationIds: string[]
+  observedProperty: string[]
+  workedOrderNo: any[]
+  samplingAgency: string[]
+  analyzingAgency: string[]
+  analyticalMethod: string[]
+  collectionMethod: string[]
+  qcSampleType: string[]
+  dataClassification: string[]
+  sampleDepth: string
+  labBatchId: string
+  specimenId: string
 }

--- a/frontend/src/interfaces/AdvanceSearchFormType.ts
+++ b/frontend/src/interfaces/AdvanceSearchFormType.ts
@@ -1,4 +1,4 @@
-import BasicSearchFormType from "./BasicSearchFormType"
+import type BasicSearchFormType from "./BasicSearchFormType"
 
 export default interface AdvanceSearchFormType extends BasicSearchFormType {
   observationIds: string[]

--- a/frontend/src/pages/AdvanceSearch.tsx
+++ b/frontend/src/pages/AdvanceSearch.tsx
@@ -105,7 +105,7 @@ const AdvanceSearch = (props: Props) => {
     permitNumber: [],
     media: [],
     observedProperty: [],
-    workedOrderNo: null,
+    workedOrderNo: [],
     samplingAgency: [],
     analyzingAgency: [],
     projects: [],
@@ -129,7 +129,9 @@ const AdvanceSearch = (props: Props) => {
       permitNumber: params.permitNumber.toString(),
       media: params.media.toString(),
       observedProperty: params.observedProperty.toString(),
-      workedOrderNo: params.workedOrderNo?.id || "",
+      workedOrderNo: Array.isArray(params.workedOrderNo)
+        ? params.workedOrderNo.map((wo: any) => wo?.id || "").join(",")
+        : params.workedOrderNo?.id || "",
       samplingAgency: params.samplingAgency.toString(),
       analyzingAgency: params.analyzingAgency.toString(),
       projects: params.projects.toString(),
@@ -145,7 +147,11 @@ const AdvanceSearch = (props: Props) => {
       locationTypeCustomId: params.locationType
         ? params.locationType?.customId
         : "",
-      workOrderNoText: params.workedOrderNo ? params.workedOrderNo?.text : "",
+      workOrderNoText: Array.isArray(params.workedOrderNo)
+        ? params.workedOrderNo.map((wo: any) => wo?.text || "").join(", ")
+        : params.workedOrderNo
+          ? params.workedOrderNo?.text
+          : "",
     }
 
     let urlString = ""
@@ -370,6 +376,9 @@ const AdvanceSearch = (props: Props) => {
         data[key] = arr
       } else if (key === "fromDate" || key === "toDate") {
         data[key] = formData[key] ? formData[key].toISOString() : ""
+      } else if (key === SearchAttr.WorkedOrderNo && formData[key]) {
+        // Wrap single workedOrderNo object in array
+        data[key] = [formData[key]]
       }
     }
     return data

--- a/migrations/sql/V1.1.8__new_analysis_method_nameID_vw.sql
+++ b/migrations/sql/V1.1.8__new_analysis_method_nameID_vw.sql
@@ -1,0 +1,12 @@
+DROP MATERIALIZED VIEW IF EXISTS mv_aqi_analysis_method;
+DROP MATERIALIZED VIEW IF EXISTS mv_aqi_analysis_method_collection;
+CREATE MATERIALIZED VIEW mv_aqi_analysis_method_collection AS
+SELECT DISTINCT
+    Analysis_Method_ID,
+    Analysis_Method
+FROM AQI_CSV_IMPORT_STAGING
+WHERE Analysis_Method IS NOT NULL
+  AND Analysis_Method_ID IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_aqi_analysis_method_collection
+  ON mv_aqi_analysis_method_collection (Analysis_Method_ID, Analysis_Method);

--- a/migrations/sql/V1.1.9__update_refresh_vw_function.sql
+++ b/migrations/sql/V1.1.9__update_refresh_vw_function.sql
@@ -1,0 +1,37 @@
+-- Refreshes all AQI lookup materialized views.
+-- Safe to call inside other functions/transactions (NO CONCURRENTLY here).
+
+CREATE OR REPLACE FUNCTION refresh_aqi_lookup_materialized_views()
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    -- Location & org fields
+    REFRESH MATERIALIZED VIEW mv_aqi_sampling_agency;
+    REFRESH MATERIALIZED VIEW mv_aqi_project;
+    REFRESH MATERIALIZED VIEW mv_aqi_work_order_number;
+    REFRESH MATERIALIZED VIEW mv_aqi_location_type;
+    REFRESH MATERIALIZED VIEW mv_aqi_location_group;
+    REFRESH MATERIALIZED VIEW mv_aqi_location_collection;
+
+    -- Field/sample attributes
+    REFRESH MATERIALIZED VIEW mv_aqi_collection_method;
+    REFRESH MATERIALIZED VIEW mv_aqi_medium;
+
+    -- Observed property & chemistry metadata
+    REFRESH MATERIALIZED VIEW mv_aqi_observed_property_id;
+    REFRESH MATERIALIZED VIEW mv_aqi_observed_property_name;
+    REFRESH MATERIALIZED VIEW mv_aqi_observed_property_description;
+    REFRESH MATERIALIZED VIEW mv_aqi_observed_property_analysis_type;
+    REFRESH MATERIALIZED VIEW mv_aqi_observed_property_result_type;
+
+    -- Result metrics & units
+    REFRESH MATERIALIZED VIEW mv_aqi_data_classification;
+
+    -- Lab / analysis metadata
+    REFRESH MATERIALIZED VIEW mv_aqi_analyzing_agency;
+    REFRESH MATERIALIZED VIEW mv_aqi_analysis_method_collection;
+    REFRESH MATERIALIZED VIEW mv_aqi_lab_batch_id;
+    REFRESH MATERIALIZED VIEW mv_aqi_qc_type;
+END;
+$$;


### PR DESCRIPTION
This pull request introduces a small change to the `FilterResultsForm` component to enhance its functionality. The most important update is the addition of support for selecting multiple values in the `Autocomplete` input for work order numbers.

Improvements to form functionality:

* Enabled the `multiple` prop on the `Autocomplete` component in `FilterResultsForm.tsx`, allowing users to select more than one work order number.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-enmods-wr-135-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-enmods-wr-135-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-enmods-wr/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-enmods-wr/actions/workflows/merge.yml)