### PR TITLE
fix: Fix locationTypeCustomId normalization in search controller

### DIFF
--- a/backend/src/search/search.controller.ts
+++ b/backend/src/search/search.controller.ts
@@ -75,8 +75,17 @@ export class SearchController {
               customId: queryParams.locationTypeCustomId,
             }
           : "";
-      } else if (key !== "locationTypeCustomId") {
-        // Copy other fields as-is, excluding the intermediate fields
+      } else if (key === "locationTypeCustomId") {
+        // Handle locationTypeCustomId - if locationType wasn't set, try to use just customId
+        if (!queryParams.locationType && queryParams.locationTypeCustomId) {
+          normalized["locationType"] = {
+            id: queryParams.locationTypeCustomId,
+            customId: queryParams.locationTypeCustomId,
+          };
+        }
+        // Otherwise skip it as it was already processed with locationType above
+      } else {
+        // Copy other fields as-is
         normalized[key] = value || "";
       }
     }
@@ -129,7 +138,6 @@ export class SearchController {
           <body>
             <h2>Error</h2>
             <p>${job.error || "An error occurred while processing your request"}</p>
-            <p><a href="javascript:history.back()">Go back</a></p>
           </body>
         </html>
       `;


### PR DESCRIPTION
This pull request updates the `SearchController` to improve how search query parameters related to location types are normalized and makes a minor change to the error HTML template. The main focus is on handling the `locationTypeCustomId` parameter more robustly, ensuring that it is correctly processed when `locationType` is not provided.

**Improvements to query parameter normalization:**

* Enhanced the logic for handling the `locationTypeCustomId` parameter: if `locationType` isn't set but `locationTypeCustomId` is present, the controller now creates a `locationType` object using `locationTypeCustomId` for both `id` and `customId`. This ensures better support for custom location types in search queries.

**UI/Error handling:**

* Removed the "Go back" link from the error page HTML template, simplifying the error message display.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-enmods-wr-136-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-enmods-wr-136-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-enmods-wr/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-enmods-wr/actions/workflows/merge.yml)