### PR TITLE
feat: Add geodata CronJob and externalize scheduling

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -8,17 +8,15 @@ import { MetricsController } from "./metrics.controller";
 import { TerminusModule } from "@nestjs/terminus";
 import { SearchModule } from "./search/search.module";
 import { GeodataModule } from "./geodata/geodata.module";
-import { ScheduleModule } from "@nestjs/schedule";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import ormconfig from "src/ormconfig";
 import { ObservationsModule } from "./observations/observations.module";
-import { S3SyncLogModule } from './s3_sync_log/s3_sync_log.module';
+import { S3SyncLogModule } from "./s3_sync_log/s3_sync_log.module";
 
 @Module({
   imports: [
     TypeOrmModule.forRoot(ormconfig),
     ConfigModule.forRoot(),
-    ScheduleModule.forRoot(),
     TerminusModule,
     SearchModule,
     GeodataModule,

--- a/backend/src/geodata-cronjob.ts
+++ b/backend/src/geodata-cronjob.ts
@@ -1,0 +1,59 @@
+/**
+ * Standalone script for running the GeodataService processAndUpload job as an OpenShift CronJob.
+ * This is invoked via the geodata-cronjob.yaml Helm template instead of using @Cron decorator.
+ *
+ * Usage: node geodata-cronjob.js
+ */
+
+import "dotenv/config";
+import { DataSource } from "typeorm";
+import { Logger } from "@nestjs/common";
+import ormconfig from "src/ormconfig";
+import { GeodataService } from "./geodata/geodata.service";
+
+const logger = new Logger("GeodataSync");
+
+async function runGeodataSync() {
+  let dataSource: DataSource | null = null;
+
+  try {
+    logger.log("Initializing database connection...");
+
+    // Create and initialize the data source
+    dataSource = new DataSource(ormconfig as any);
+    await dataSource.initialize();
+
+    logger.log("Database connection established");
+
+    // Get the FileInfo repository to pass to GeodataService
+    const fileInfoRepository = dataSource.getRepository("FileInfo");
+
+    // Instantiate the GeodataService
+    logger.log("Instantiating GeodataService...");
+    const geodataService = new GeodataService(fileInfoRepository);
+
+    // Run the processAndUpload method
+    logger.log("Starting geodata sync process...");
+    await geodataService.processAndUpload();
+
+    logger.log("Geodata sync process completed successfully");
+    process.exit(0);
+  } catch (error) {
+    logger.error(
+      `Error during geodata sync: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    if (error instanceof Error && error.stack) {
+      logger.error(error.stack);
+    }
+    process.exit(1);
+  } finally {
+    // Clean up database connection
+    if (dataSource && dataSource.isInitialized) {
+      logger.log("Closing database connection...");
+      await dataSource.destroy();
+    }
+  }
+}
+
+// Run the cronjob
+runGeodataSync();

--- a/backend/src/geodata-cronjob.ts
+++ b/backend/src/geodata-cronjob.ts
@@ -10,6 +10,7 @@ import { DataSource } from "typeorm";
 import { Logger } from "@nestjs/common";
 import ormconfig from "src/ormconfig";
 import { GeodataService } from "./geodata/geodata.service";
+import { FileInfo } from "./geodata/entities/file-info.entity";
 
 const logger = new Logger("GeodataSync");
 
@@ -26,7 +27,7 @@ async function runGeodataSync() {
     logger.log("Database connection established");
 
     // Get the FileInfo repository to pass to GeodataService
-    const fileInfoRepository = dataSource.getRepository("FileInfo");
+    const fileInfoRepository = dataSource.getRepository(FileInfo);
 
     // Instantiate the GeodataService
     logger.log("Instantiating GeodataService...");

--- a/backend/src/geodata/geodata.service.ts
+++ b/backend/src/geodata/geodata.service.ts
@@ -1,6 +1,5 @@
 import "multer";
 import { Injectable, Logger } from "@nestjs/common";
-import { Cron, CronExpression } from "@nestjs/schedule";
 import axios from "axios";
 import * as crypto from "crypto";
 import * as fs from "fs";
@@ -42,9 +41,8 @@ export class GeodataService {
     wellTagNumber: null,
   };
 
-  @Cron(process.env.GEODATA_REFRESH_CRON || CronExpression.EVERY_DAY_AT_2AM, {
-    timeZone: "America/Vancouver",
-  })
+  // Note: This method is now invoked via OpenShift CronJob instead of scheduled from the backend.
+  // See charts/app/templates/geodata-cronjob.yaml for the cronjob configuration.
   async processAndUpload(): Promise<void> {
     try {
       this.logger.debug("Starting sampling location cron job");

--- a/charts/app/templates/cron.yaml
+++ b/charts/app/templates/cron.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: "{{ .Release.Namespace }}"
 spec:
   schedule: "0 23 * * 1" #change this to every saturday at midnight
+  timeZone: "America/Vancouver"
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 2
   jobTemplate:

--- a/charts/app/templates/geodata-cronjob.yaml
+++ b/charts/app/templates/geodata-cronjob.yaml
@@ -44,31 +44,31 @@ spec:
                 - name: BASE_URL_BC_API
                   valueFrom:
                     secretKeyRef:
-                      name: "{{ .Release.Name }}-geodata"
+                      name: "{{ .Release.Name }}-backend"
                       key: BASE_URL_BC_API
                       optional: true
                 - name: AUTH_TOKEN
                   valueFrom:
                     secretKeyRef:
-                      name: "{{ .Release.Name }}-geodata"
+                      name: "{{ .Release.Name }}-backend"
                       key: AUTH_TOKEN
                       optional: true
                 - name: SAMPLING_LOCATIONS_ENDPOINT
                   valueFrom:
                     secretKeyRef:
-                      name: "{{ .Release.Name }}-geodata"
+                      name: "{{ .Release.Name }}-backend"
                       key: SAMPLING_LOCATIONS_ENDPOINT
                       optional: true
                 - name: SAMPLING_LOCATION_GROUPS_ENDPOINT
                   valueFrom:
                     secretKeyRef:
-                      name: "{{ .Release.Name }}-geodata"
+                      name: "{{ .Release.Name }}-backend"
                       key: SAMPLING_LOCATION_GROUPS_ENDPOINT
                       optional: true
                 - name: EXTENDED_ATTRIBUTES_ENDPOINT
                   valueFrom:
                     secretKeyRef:
-                      name: "{{ .Release.Name }}-geodata"
+                      name: "{{ .Release.Name }}-backend"
                       key: EXTENDED_ATTRIBUTES_ENDPOINT
                       optional: true
 
@@ -76,31 +76,31 @@ spec:
                 - name: OBJECTSTORE_URL
                   valueFrom:
                     secretKeyRef:
-                      name: "{{ .Release.Name }}-geodata"
+                      name: "{{ .Release.Name }}-backend"
                       key: OBJECTSTORE_URL
                       optional: true
                 - name: OBJECTSTORE_BUCKET
                   valueFrom:
                     secretKeyRef:
-                      name: "{{ .Release.Name }}-geodata"
+                      name: "{{ .Release.Name }}-backend"
                       key: OBJECTSTORE_BUCKET
                       optional: true
                 - name: OBJECTSTORE_FOLDER
                   valueFrom:
                     secretKeyRef:
-                      name: "{{ .Release.Name }}-geodata"
+                      name: "{{ .Release.Name }}-backend"
                       key: OBJECTSTORE_FOLDER
                       optional: true
                 - name: OBJECTSTORE_ACCESS_KEY
                   valueFrom:
                     secretKeyRef:
-                      name: "{{ .Release.Name }}-geodata"
+                      name: "{{ .Release.Name }}-backend"
                       key: OBJECTSTORE_ACCESS_KEY
                       optional: true
                 - name: OBJECTSTORE_SECRET_KEY
                   valueFrom:
                     secretKeyRef:
-                      name: "{{ .Release.Name }}-geodata"
+                      name: "{{ .Release.Name }}-backend"
                       key: OBJECTSTORE_SECRET_KEY
                       optional: true
 

--- a/charts/app/templates/geodata-cronjob.yaml
+++ b/charts/app/templates/geodata-cronjob.yaml
@@ -21,10 +21,7 @@ spec:
               env:
                 # Database credentials
                 - name: POSTGRES_HOST
-                  valueFrom:
-                    secretKeyRef:
-                      name: "{{ .Release.Name }}-database"
-                      key: POSTGRES_HOST
+                  value: "{{ .Release.Name }}-bitnami-pg.{{ .Release.Namespace }}.svc.cluster.local"
                 - name: POSTGRES_USER
                   valueFrom:
                     secretKeyRef:

--- a/charts/app/templates/geodata-cronjob.yaml
+++ b/charts/app/templates/geodata-cronjob.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ .Release.Name }}-geodata-sync
   namespace: "{{ .Release.Namespace }}"
 spec:
-  # Schedule: Every day at 2 AM Vancouver time (changed to 4 AM UTC to account for PDT/PST)
-  schedule: "{{ .Values.global.geodataSync.schedule | default \"0 2 * * *\" }}"
+  # Schedule: Every day at 2 AM Vancouver time (in America/Vancouver timezone)
+  schedule: "{{ .Values.global.geodataSync.schedule | default "0 2 * * *" }}"
   timeZone: "America/Vancouver"
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 2

--- a/charts/app/templates/geodata-cronjob.yaml
+++ b/charts/app/templates/geodata-cronjob.yaml
@@ -1,0 +1,123 @@
+{{- if .Values.global.geodataSync.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-geodata-sync
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  # Schedule: Every day at 2 AM Vancouver time (changed to 4 AM UTC to account for PDT/PST)
+  schedule: "{{ .Values.global.geodataSync.schedule | default \"0 2 * * *\" }}"
+  timeZone: "America/Vancouver"
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 2
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: geodata-sync
+              image: "{{.Values.global.registry}}/{{.Values.global.repository}}/backend:{{ .Values.global.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: IfNotPresent
+              env:
+                # Database credentials
+                - name: POSTGRES_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Release.Name }}-database"
+                      key: POSTGRES_HOST
+                - name: POSTGRES_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Release.Name }}-database"
+                      key: POSTGRES_USER
+                - name: POSTGRES_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Release.Name }}-database"
+                      key: POSTGRES_PASSWORD
+                - name: POSTGRES_DATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Release.Name }}-database"
+                      key: POSTGRES_DATABASE
+
+                # BC API credentials
+                - name: BASE_URL_BC_API
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Release.Name }}-geodata"
+                      key: BASE_URL_BC_API
+                      optional: true
+                - name: AUTH_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Release.Name }}-geodata"
+                      key: AUTH_TOKEN
+                      optional: true
+                - name: SAMPLING_LOCATIONS_ENDPOINT
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Release.Name }}-geodata"
+                      key: SAMPLING_LOCATIONS_ENDPOINT
+                      optional: true
+                - name: SAMPLING_LOCATION_GROUPS_ENDPOINT
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Release.Name }}-geodata"
+                      key: SAMPLING_LOCATION_GROUPS_ENDPOINT
+                      optional: true
+                - name: EXTENDED_ATTRIBUTES_ENDPOINT
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Release.Name }}-geodata"
+                      key: EXTENDED_ATTRIBUTES_ENDPOINT
+                      optional: true
+
+                # ObjectStore/S3 credentials
+                - name: OBJECTSTORE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Release.Name }}-geodata"
+                      key: OBJECTSTORE_URL
+                      optional: true
+                - name: OBJECTSTORE_BUCKET
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Release.Name }}-geodata"
+                      key: OBJECTSTORE_BUCKET
+                      optional: true
+                - name: OBJECTSTORE_FOLDER
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Release.Name }}-geodata"
+                      key: OBJECTSTORE_FOLDER
+                      optional: true
+                - name: OBJECTSTORE_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Release.Name }}-geodata"
+                      key: OBJECTSTORE_ACCESS_KEY
+                      optional: true
+                - name: OBJECTSTORE_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Release.Name }}-geodata"
+                      key: OBJECTSTORE_SECRET_KEY
+                      optional: true
+
+                - name: NODE_ENV
+                  value: "production"
+
+              command:
+                - node
+                - --max-old-space-size=1024
+                - /app/dist/geodata-cronjob.js
+
+              # Resource limits
+              resources:
+                requests:
+                  memory: "512Mi"
+                  cpu: "100m"
+          restartPolicy: OnFailure
+          serviceAccountName: default
+{{- end }}

--- a/charts/app/templates/geodata-cronjob.yaml
+++ b/charts/app/templates/geodata-cronjob.yaml
@@ -12,6 +12,8 @@ spec:
   failedJobsHistoryLimit: 2
   jobTemplate:
     spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 28800  # 8 hours to allow the job to complete
       template:
         spec:
           containers:

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -55,6 +55,11 @@ global:
   domain: "apps.silver.devops.gov.bc.ca" # it is apps.gold.devops.gov.bc.ca for gold cluster
   #-- the database Alias gives a nice way to switch to different databases, crunchy, patroni ... etc.
   databaseAlias: bitnami-pg
+  #-- geodata synchronization cronjob configuration
+  geodataSync:
+    enabled: true
+    #-- cron schedule for the geodata sync job (in "America/Vancouver" timezone)
+    schedule: "0 2 * * *" # Daily at 2 AM Vancouver time
 #-- the components of the application, backend.
 backend:
   #-- enable or disable backend


### PR DESCRIPTION
Introduce a standalone geodata-cronjob script and Helm CronJob template to run GeodataService.processAndUpload as an OpenShift CronJob instead of using Nest's scheduler. Removed the ScheduleModule import and the @Cron decorator from GeodataService so scheduling is managed by the cluster. Added charts/app/templates/geodata-cronjob.yaml and enabled geodataSync configuration in charts/app/values.yaml (default daily at 2 AM Vancouver). Also minor import style cleanup in app.module.ts.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-enmods-wr-146-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-enmods-wr-146-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-enmods-wr/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-enmods-wr/actions/workflows/merge.yml)