### PR TITLE
fix: Correct an env variable issue that only affects prod

### DIFF
--- a/backend/src/geodata/geodata.service.ts
+++ b/backend/src/geodata/geodata.service.ts
@@ -120,7 +120,7 @@ export class GeodataService {
     axios.defaults.method = "GET";
     axios.defaults.headers.common["Authorization"] =
       "token " + process.env.AUTH_TOKEN;
-    axios.defaults.headers.common["x-api-key"] = process.env.AUTH_TOKEN;
+    axios.defaults.headers.common["x-api-key"] = process.env.API_KEY;
     const url = `${this.baseUrl}${this.extendedAttributesEndpoint}`;
     const response = await axios.get(url);
 
@@ -292,7 +292,7 @@ export class GeodataService {
     axios.defaults.method = "GET";
     axios.defaults.headers.common["Authorization"] =
       "token " + process.env.AUTH_TOKEN;
-    axios.defaults.headers.common["x-api-key"] = process.env.AUTH_TOKEN;
+    axios.defaults.headers.common["x-api-key"] = process.env.API_KEY;
 
     this.logger.debug("Fetching sampling locations...");
     const start = Date.now();


### PR DESCRIPTION
- Test doesn't require an x-api-key but prod does
- Fix bug where incorrect x-api-key was being added to requests

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-enmods-wr-148-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-enmods-wr-148-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-enmods-wr/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-enmods-wr/actions/workflows/merge.yml)